### PR TITLE
Added command switch to guess Kubernetes API settings from POD environment 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 .PHONY: vendor_clean vendor_fetch vendor_update vendor_sync install build doc fmt lint test vet godep bench
 
 PKG_NAME=$(shell basename `pwd`)
+TARGET_OS="linux"
+CONTAINER_NAME=$(shell grep "FROM " contrib/docker/Dockerfile | sed 's/FROM \(.*\).*\:.*/\1/')
+CONTAINER_VERSION=$(shell grep "FROM " contrib/docker/Dockerfile | sed 's/FROM .*\:\(.*\).*/\1/')
 
 default: install
 
@@ -21,6 +24,14 @@ install: vendor_sync
 
 build: vendor_sync
 	go build -v -o ./bin/$(PKG_NAME)
+
+docker: docker_build docker_container
+
+docker_container:
+	docker build -t $(CONTAINER_NAME)-kube-template:$(CONTAINER_VERSION) ./contrib/docker
+
+docker_build:
+	CGO_ENABLED=0 GOOS=$(TARGET_OS) go build -a -installsuffix cgo -v -o ./contrib/docker/bin/$(PKG_NAME)
 
 clean: vendor_clean
 	rm -dRf ./bin

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Installation
 - `make install`
 
 Docker
+
 If you want to create a Docker image
 - adjust Dockerfile in contrib/docker directory to fit your needs
 - configure settings files in contrib/docker/conf directory

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Installation
 - `cd kube-template`
 - `make install`
 
+Docker
+If you want to create a Docker image
+- adjust Dockerfile in contrib/docker directory to fit your needs
+- configure settings files in contrib/docker/conf directory
+- issue `make docker`
+
+Note - the built image is already configured to automatically locate Kubernetes API along with everything is needed to connect (e.g. Certificate Authority file, security token and so on). 
+
 Usage
 -----
 
@@ -23,6 +31,7 @@ Usage
       --alsologtostderr                  log to standard error as well as files
   -c, --config string                    config file (default is ./kube-template.(yaml|json))
       --dry-run                          don't write template output, dump result to stdout
+      --guess-kube-api-settings          guess Kubernetes API settings from POD environment
       --help-md                          get help in Markdown format
       --log-backtrace-at traceLocation   when logging hits line file:N, emit a stack trace (default :0)
       --log-dir string                   If non-empty, write log files in this directory

--- a/cfg.go
+++ b/cfg.go
@@ -37,6 +37,8 @@ type Config struct {
 	DryRun bool
 	// Run template processing once and exit
 	RunOnce bool
+        // Guess Kubernetes API settings from POD environment
+        GuessKubeAPISettings bool
 	// Kubernetes API server address
 	Master string
 	// Kubernetes API server poll time
@@ -125,6 +127,14 @@ func newConfig(cmd *cobra.Command) (*Config, error) {
 		return nil, err
 	}
 	config.RunOnce = runOnce
+	guessKubeAPISettings, err := cmd.Flags().GetBool(FLAG_GUESS_KUBE_API_SETTINGS)
+	if err != nil {
+		return nil, err
+	}
+	config.GuessKubeAPISettings = guessKubeAPISettings
+
+
+
 	// Read config from file, if present
 	err = readConfig(cmd)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -30,15 +30,22 @@ type Client struct {
 }
 
 func newClient(cfg *Config) (*Client, error) {
-	host := DEFAULT_MASTER_HOST
-	if cfg.Master != "" {
+        var config = new (rest.Config)
+        if cfg.GuessKubeAPISettings {
+           var err error
+           config, err = rest.InClusterConfig()
+	   if err != nil {
+		return nil, err
+	   }
+        } else {
+	    host := DEFAULT_MASTER_HOST
+	    if cfg.Master != "" {
 		host = cfg.Master
-	}
-
-	config := &rest.Config{
+	    }
+	    config = &rest.Config{
 		Host: host,
-	}
-
+	    }
+        }
 	c, err := kubernetes.NewForConfig(config)
 	if err != nil {
 		return nil, err

--- a/cmd.go
+++ b/cmd.go
@@ -40,6 +40,7 @@ const (
 	FLAG_POLL_TIME = "poll-time"
 	FLAG_TEMPLATE  = "template"
 	FLAG_HELP_MD   = "help-md"
+        FLAG_GUESS_KUBE_API_SETTINGS = "guess-kube-api-settings"
 )
 
 func newCmd() *cobra.Command {
@@ -57,6 +58,7 @@ func initCmd(cmd *cobra.Command) {
 	f := cmd.Flags()
 	f.Bool(FLAG_DRY_RUN, false, "don't write template output, dump result to stdout")
 	f.Bool(FLAG_RUN_ONCE, false, "run template processing once and exit")
+	f.Bool(FLAG_GUESS_KUBE_API_SETTINGS, false, "guess Kubernetes API settings from POD environment")
 	f.String(FLAG_MASTER, "", fmt.Sprintf("Kubernetes API server address (default is %s)", DEFAULT_MASTER_HOST))
 	f.DurationP(FLAG_POLL_TIME, "p", 15*time.Second, "Kubernetes API server poll time (0 disables server polling)")
 	f.StringVarP(&cfgFile, FLAG_CONFIG, "c", "", fmt.Sprintf("config file (default is ./%s.(yaml|json))", CFG_FILE))

--- a/contrib/docker/Dockerfile
+++ b/contrib/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM alpine:latest
+
+MAINTAINER: me@foo.org
+
+COPY bin/kube-template /usr/bin/kube-template
+COPY conf/kube-template.yaml /usr/bin/kube-template.yaml
+COPY conf/in.txt.tmpl /etc/kube-template/in.txt.tmpl
+
+RUN set -o pipefail && \
+addgroup -g 987 kube  && \
+adduser -h /home/kube -u 990 -G kube -g "Kubernetes user" -S -D kube  && \
+mkdir -m 775 /var/lib/kube-template  && \
+chown kube: /var/lib/kube-template  && \
+chown -R kube: /etc/kube-template  && \
+chmod 775 /etc/kube-template  && \
+chmod 640 /etc/kube-template/in.txt.tmpl  && \
+chown kube: /usr/bin/kube-template.yaml  && \
+chmod 640 /usr/bin/kube-template.yaml  && \
+chmod 755 /usr/bin/kube-template
+
+WORKDIR /usr/bin
+USER kube
+
+CMD ["--guess-kube-api-settings"]
+ENTRYPOINT ["/usr/bin/kube-template"]

--- a/contrib/docker/conf/in.txt.tmpl
+++ b/contrib/docker/conf/in.txt.tmpl
@@ -1,0 +1,3 @@
+{{range pods "" "my-namespace"}}
+  {{.Name}} {{.Status.PodIP}}
+{{end}}

--- a/contrib/docker/conf/kube-template.yaml
+++ b/contrib/docker/conf/kube-template.yaml
@@ -1,0 +1,5 @@
+poll-time: 10s
+
+templates:
+  - path: /etc/kube-templates/in.txt.tmpl
+    output: /var/lib/kube-templates/out.txt


### PR DESCRIPTION
Hello. I've just added a command switch to guess Kubernetes API settings from POD environment: it is usefull if you run kube-template inside a POD since it does not require additional configuration - it automatically locates Kubernetes API using system variables and loads any available credential (for example CA file, security token and so on). I did it for a customer of mine and seems to work. Hope you find it interesting. By the way I also added a Makefile target to build a Docker image and some sample files in contrib/docker/conf