### PR TITLE
Allow configurable template delimiters

### DIFF
--- a/app.go
+++ b/app.go
@@ -62,7 +62,7 @@ func newApp(cfg *Config) (*App, error) {
 	// Add all configured templates
 	app.templates = make([]*Template, 0, len(cfg.TemplateDescriptors))
 	for _, d := range cfg.TemplateDescriptors {
-		t, err := newTemplate(app.dm, d)
+		t, err := newTemplate(app.dm, d, cfg)
 		if err != nil {
 			return nil, err
 		}

--- a/cfg.go
+++ b/cfg.go
@@ -46,6 +46,10 @@ type Config struct {
 	// Kubernetes API server poll time
 	PollTime time.Duration
 
+	// Template delimiters
+	LeftDelimiter  string
+	RightDelimiter string
+
 	// Template paths
 	templatePaths map[string]bool
 
@@ -139,6 +143,18 @@ func newConfig(cmd *cobra.Command) (*Config, error) {
 		return nil, err
 	}
 	config.KubeConfig = kubeConfig
+
+	leftDelimiter, err := cmd.Flags().GetString(FLAG_LEFT_DELIM)
+	if err != nil {
+		return nil, err
+	}
+	config.LeftDelimiter = leftDelimiter
+
+	rightDelimiter, err := cmd.Flags().GetString(FLAG_RIGHT_DELIM)
+	if err != nil {
+		return nil, err
+	}
+	config.RightDelimiter = rightDelimiter
 
 	// Read config from file, if present
 	err = readConfig(cmd)

--- a/cmd.go
+++ b/cmd.go
@@ -42,6 +42,8 @@ const (
 	FLAG_HELP_MD                 = "help-md"
 	FLAG_GUESS_KUBE_API_SETTINGS = "guess-kube-api-settings"
 	FLAG_KUBE_CONFIG             = "kube-config"
+	FLAG_LEFT_DELIM              = "left-delimiter"
+	FLAG_RIGHT_DELIM             = "right-delimiter"
 )
 
 func newCmd() *cobra.Command {
@@ -64,6 +66,8 @@ func initCmd(cmd *cobra.Command) {
 	f.String(FLAG_MASTER, "", fmt.Sprintf("Kubernetes API server address (default is %s)", DEFAULT_MASTER_HOST))
 	f.DurationP(FLAG_POLL_TIME, "p", 15*time.Second, "Kubernetes API server poll time (0 disables server polling)")
 	f.StringP(FLAG_KUBE_CONFIG, "k", "", "Kubernetes config file to use")
+	f.StringP(FLAG_LEFT_DELIM, "l", "{{", "templating left delimiter (default is {{)")
+	f.StringP(FLAG_RIGHT_DELIM, "r", "}}", "templating right delimiter (default is }})")
 	f.StringVarP(&cfgFile, FLAG_CONFIG, "c", "", fmt.Sprintf("config file (default is ./%s.(yaml|json))", CFG_FILE))
 	f.StringSliceP(FLAG_TEMPLATE, "t", nil, `adds a new template to watch on disk in the format
 		'templatePath:outputPath[:command]'. This option is additive

--- a/template.go
+++ b/template.go
@@ -23,9 +23,10 @@ import (
 
 	gotemplate "text/template"
 
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strings"
 )
 
 const (
@@ -47,7 +48,7 @@ type Template struct {
 	lastOutput string
 }
 
-func newTemplate(dm *DependencyManager, d *TemplateDescriptor) (*Template, error) {
+func newTemplate(dm *DependencyManager, d *TemplateDescriptor, cfg *Config) (*Template, error) {
 	// Template name
 	name := filepath.Base(d.Path)
 	// Get last template output, if present
@@ -62,7 +63,7 @@ func newTemplate(dm *DependencyManager, d *TemplateDescriptor) (*Template, error
 	}
 	s := string(data)
 	// Create Go template from read data
-	template, err := gotemplate.New(name).Funcs(funcMap(dm)).Parse(s)
+	template, err := gotemplate.New(name).Delims(cfg.LeftDelimiter, cfg.RightDelimiter).Funcs(funcMap(dm)).Parse(s)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Those templates may find their way into otherwise go-templatized
files (in our case, in Helm charts). Configuring delimiters
prevent templating clashs.